### PR TITLE
check for flipY on the texture used

### DIFF
--- a/packages/three-particle-emitter/src/index.ts
+++ b/packages/three-particle-emitter/src/index.ts
@@ -161,7 +161,7 @@ export class ParticleEmitter extends Mesh {
   }
 
   updateParticles() {
-    const texture = super.material ? (super.material as ShaderMaterial).uniforms.map.value: null;
+    const texture = (super.material as ShaderMaterial).uniforms.map.value;
     const planeGeometry = new PlaneBufferGeometry(1, 1, 1, 1, texture && texture.flipY);
     const tempGeo = new InstancedBufferGeometry();
     tempGeo.index = planeGeometry.index;

--- a/packages/three-particle-emitter/src/index.ts
+++ b/packages/three-particle-emitter/src/index.ts
@@ -109,7 +109,7 @@ export class ParticleEmitter extends Mesh {
   inverseWorldScale: Vector3;
 
   constructor(texture: Texture) {
-    const planeGeometry = new PlaneBufferGeometry();
+    const planeGeometry = new PlaneBufferGeometry(1, 1, 1, 1, texture && texture.flipY);
     const geometry = new InstancedBufferGeometry();
     geometry.index = planeGeometry.index;
     geometry.attributes = planeGeometry.attributes;
@@ -161,7 +161,8 @@ export class ParticleEmitter extends Mesh {
   }
 
   updateParticles() {
-    const planeGeometry = new PlaneBufferGeometry();
+    const texture = super.material ? (super.material as ShaderMaterial).uniforms.map.value: null;
+    const planeGeometry = new PlaneBufferGeometry(1, 1, 1, 1, texture && texture.flipY);
     const tempGeo = new InstancedBufferGeometry();
     tempGeo.index = planeGeometry.index;
     tempGeo.attributes = planeGeometry.attributes;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6591,7 +6591,7 @@ text-extensions@^2.0.0:
 
 "three@github:mozillareality/three.js#hubs/master":
   version "0.105.1"
-  resolved "https://codeload.github.com/mozillareality/three.js/tar.gz/6041920b6f3c8929ee631a5e14460bf9db85835d"
+  resolved "https://codeload.github.com/mozillareality/three.js/tar.gz/7456c6392ade9815104a0f17188bfd3f940799b3"
 
 through2@^2.0.0, through2@^2.0.2:
   version "2.0.5"


### PR DESCRIPTION
This fixes the issue in Hubs where the texture for particles are upside-down.