### PR TITLE
Add script to help setup linking to hubs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This repository is setup as a monorepo using [lerna](https://lerna.js.org/) and 
 
 ### Setup
 
-If you haven't already, install node, yarn and lerna:
+If you haven't already, install `node`, `yarn` and `lerna`:
 
 [Install Node](https://nodejs.org/)
 
@@ -13,6 +13,12 @@ Then run:
 ```
 npm install -g yarn
 yarn global add lerna
+```
+
+You may need to add the directory where yarn installs global packages like `lerna` to your path. For example, in `bash`:
+```sh
+# in ~/.bashrc
+export PATH="$(yarn global bin):$PATH"
 ```
 
 ### Bootstrapping
@@ -74,6 +80,8 @@ yarn link three-particle-emitter
 ```
 
 Now three-particle-emitter is linked into hubs and will rebuild whenever it is changed.
+
+(Optional alternative) There is a script called `/scripts/setup-hubs-links.sh` that will attempt to setup links between this directory and your `hubs` directory. It makes sure that they refer to the same version of `THREE.js` and it avoids a naming conflict where `hubs` code refers to `<dir_hubs>/node_modules/lib-hubs` whereas the usual link method creates a directory at `<dir_hubs>/node_modules/@mozillareality/three-particle-emitter`, and so is not used by default.
 
 ### Publishing
 

--- a/scripts/setup-hubs-links.sh
+++ b/scripts/setup-hubs-links.sh
@@ -1,0 +1,46 @@
+echo "OK! Attempting to set up links to lib-hubs in hubs for you..."
+echo ""
+echo "Before running this script, install dependencies the usual way:"
+echo "    in hubs:        npm ci"
+echo "    in lib-hubs:    lerna bootstrap"
+echo "And open this script in a text editor to change dir_hubs and dir_lib_hubs to the correct paths for your system."
+echo ""
+
+dir_hubs=""
+dir_lib_hubs=""
+#dir_hubs="/home/jomb/src/hubs"
+#dir_lib_hubs="/home/jomb/src/lib-hubs"
+
+if [ -z "$dir_hubs" ]; then
+   echo "Error: You must edit this script and set dir_hubs to the directory where hubs is installed.";
+   exit 0;
+elif [ -z "$dir_lib_hubs" ]; then
+   echo "Error: You must edit this script and set dir_lib_hubs to the directory where lib-hubs is installed.";
+   exit 0;
+fi
+
+
+echo "Removing lib-hubs from hubs/node_modules."
+# Remove symbolic links first, so we don't accidentally blow away linked files
+rm "${dir_hubs}/node_modules/lib-hubs"
+# If it isn't a sym link, we DO actually want to remove the files in this directory
+rm -rf "${dir_hubs}/node_modules/lib-hubs"
+
+echo "Removing three from lib-hubs/node_modules."
+# Remove symbolic links first, so we don't accidentally blow away linked files
+rm "${dir_lib_hubs}/node_modules/three"
+# If it isn't a sym link, we DO actually want to remove the files in this directory
+rm -rf "${dir_lib_hubs}/node_modules/three"
+
+echo "Linking hubs/node_modules/three into lib-hubs/node_modules."
+ln -s "${dir_hubs}/node_modules/three" "${dir_lib_hubs}/node_modules/"
+
+echo "Linking lib-hubs into hubs/node_modules."
+ln -s "${dir_lib_hubs}" "${dir_hubs}/node_modules/"
+
+echo ""
+echo "Done. Here are all your linked modules:"
+ls -la $(find "${dir_hubs}/node_modules/" "${dir_lib_hubs}/node_modules" -maxdepth 1 -type l)
+
+echo ""
+echo "Now if you run \"yarn watch\" in lib-hubs, hubs should recompile on changes too."


### PR DESCRIPTION
This adds a script that works around some issues I ran into when trying to use `yarn link` to connect `lib-hubs` and `hubs`. Specifically:
 - The package name to be linked was `@mozillareality/three-particle-emitter`, so links into `hubs/node_modules/@mozillareality/three-particle-emitter`, but hubs code looks for the particle emitter in `hubs/node_modules/lib-hubs` so the linked code is unused.
 - I couldn't figure out how to get `three-particle-emitter` to use the exact same `THREE` that `hubs` uses and ran into an issue like this:
```js
// debugging in the constructor ParticleEmitter
(this instanceof THREE.Object3D)
false
(this instanceof three__WEBPACK_IMPORTED_MODULE_0__.Object3D)
true
``` 

Someone who is more familiar with `yarn` and `npm` might be able to tell me what I was doing wrong, making this script unnecessary. However it unblocked me and I wanted to add it here in case it is useful to others too. 

The output of the script is also a description of what it does:
```
[jomb@jlomb2 lib-hubs]$ ./scripts/setup-hubs-links.sh 
OK! Attempting to set up links to lib-hubs in hubs for you...

Before running this script, install dependencies the usual way:
    in hubs:        npm ci
    in lib-hubs:    lerna bootstrap
And open this script in a text editor to change dir_hubs and dir_lib_hubs to the correct paths for your system.

Removing lib-hubs from hubs/node_modules.
Removing three from lib-hubs/node_modules.
Linking hubs/node_modules/three into lib-hubs/node_modules.
Linking lib-hubs into hubs/node_modules.

Done. Here are all your linked modules:
lrwxrwxrwx 1 jomb users 23 Jul 22 16:20 /home/jomb/src/hubs/node_modules/lib-hubs -> /home/jomb/src/lib-hubs
lrwxrwxrwx 1 jomb users 32 Jul 22 14:44 /home/jomb/src/lib-hubs/node_modules/kitchen-sink-example -> ../packages/kitchen-sink-example
lrwxrwxrwx 1 jomb users 38 Jul 22 16:20 /home/jomb/src/lib-hubs/node_modules/three -> /home/jomb/src/hubs/node_modules/three

Now if you run "yarn watch" in lib-hubs, hubs should recompile on changes too.
```