### PR TITLE
Flip UV for flipY=false texture on our ends

### DIFF
--- a/packages/three-particle-emitter/src/index.ts
+++ b/packages/three-particle-emitter/src/index.ts
@@ -34,6 +34,18 @@ export function clamp(min: number, max: number, value: number) {
   return value;
 }
 
+function flipV(geometry: PlaneBufferGeometry) {
+  // Three.js seems to assume texture flipY is true for all its built in geometry
+  // but we turn this off on our texture loader since createImageBitmap in Firefox
+  // does not support flipping. Then we flip the v of uv for flipY = false texture.
+  // @TODO: There is a similar function in Hubs client core. Should we reuse it?
+  const uv = geometry.getAttribute("uv");
+  for (let i = 0; i < uv.count; i++) {
+     uv.setY(i, 1.0 - uv.getY(i));
+  }
+  return geometry;
+}
+
 const vertexShader = `
   #include <common>
 
@@ -122,7 +134,10 @@ export class ParticleEmitter extends Mesh {
   inverseWorldScale: Vector3;
 
   constructor(texture: Texture) {
-    const planeGeometry = new PlaneBufferGeometry(1, 1, 1, 1, texture && texture.flipY);
+    const planeGeometry = new PlaneBufferGeometry(1, 1, 1, 1);
+    if (texture && !texture.flipY) {
+      flipV(planeGeometry);
+    }
     const geometry = new InstancedBufferGeometry();
     geometry.index = planeGeometry.index;
     geometry.attributes = planeGeometry.attributes;
@@ -176,7 +191,10 @@ export class ParticleEmitter extends Mesh {
 
   updateParticles() {
     const texture = (this.material as ShaderMaterial).uniforms.map.value;
-    const planeGeometry = new PlaneBufferGeometry(1, 1, 1, 1, texture && texture.flipY);
+    const planeGeometry = new PlaneBufferGeometry(1, 1, 1, 1);
+    if (texture && !texture.flipY) {
+      flipV(planeGeometry);
+    }
     const tempGeo = new InstancedBufferGeometry();
     tempGeo.index = planeGeometry.index;
     tempGeo.attributes = planeGeometry.attributes;


### PR DESCRIPTION
Needed for https://github.com/mozilla/hubs/pull/4321

See https://github.com/mozilla/hubs/pull/4321#issuecomment-859188369

Background:

We Hubs are trying to replace our Three.js fork with the official Three.js and trying to remove our patches as much as possible.

We hacked Three.js `PlaneBufferGeometry` constructor to flip V of UV for `flipY=false` texture. We are trying to remove the hack and add a helper function in Hubs instead.

`three-particle-emitter` relies on the hack so we need to update it.

I'm not sure if we should have a dependency with the new helper function in Hubs from `three-particle-emitter`, so it may duplicated but defined a similar helper function in `three-particle-emitter`, too. I think it's acceptable because it's just a few lines function.