### PR TITLE
Set three commit to same as Hubs client

### DIFF
--- a/packages/kitchen-sink-example/package.json
+++ b/packages/kitchen-sink-example/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@mozillareality/three-particle-emitter": "^0.2.2",
-    "three": "github:mozillareality/three.js#hubs-patches-141"
+    "three": "github:mozillareality/three.js#65b5105908f5f135cad25fed07e25f15f3876777"
   },
   "devDependencies": {
     "@types/webgl2": "0.0.6",

--- a/packages/three-particle-emitter/package.json
+++ b/packages/three-particle-emitter/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/webgl2": "0.0.6",
     "@types/three": "0.141.0",
-    "three": "github:mozillareality/three.js#hubs-patches-141"
+    "three": "github:mozillareality/three.js#65b5105908f5f135cad25fed07e25f15f3876777"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This PR sets the ThreeJs commit to the same one as the Hubs client is using. For some reason this seems to fix an issue with building in M1 Macs.

Related https://github.com/mozilla/hubs/discussions/5603
Fixes https://github.com/mozilla/hubs/issues/5655
Closes https://github.com/mozilla/hubs/pull/5621