### PR TITLE
Replace deprecated PlaneBufferGeometry

### DIFF
--- a/packages/three-particle-emitter/lib/cjs/index.js
+++ b/packages/three-particle-emitter/lib/cjs/index.js
@@ -99,7 +99,7 @@ const fragmentShader = `
 `;
 class ParticleEmitter extends three_1.Mesh {
     constructor(texture) {
-        const planeGeometry = new three_1.PlaneBufferGeometry(1, 1, 1, 1);
+        const planeGeometry = new three_1.PlaneGeometry(1, 1, 1, 1);
         if (texture && !texture.flipY) {
             flipV(planeGeometry);
         }
@@ -154,7 +154,7 @@ class ParticleEmitter extends three_1.Mesh {
     }
     updateParticles() {
         const texture = this.material.uniforms.map.value;
-        const planeGeometry = new three_1.PlaneBufferGeometry(1, 1, 1, 1);
+        const planeGeometry = new three_1.PlaneGeometry(1, 1, 1, 1);
         if (texture && !texture.flipY) {
             flipV(planeGeometry);
         }

--- a/packages/three-particle-emitter/lib/esm/index.js
+++ b/packages/three-particle-emitter/lib/esm/index.js
@@ -1,4 +1,4 @@
-import { Mesh, InstancedBufferGeometry, PlaneBufferGeometry, ShaderMaterial, Vector3, Color, InstancedBufferAttribute, MathUtils, AddEquation, Matrix4, UniformsUtils, UniformsLib, DynamicDrawUsage } from "three";
+import { Mesh, InstancedBufferGeometry, PlaneGeometry, ShaderMaterial, Vector3, Color, InstancedBufferAttribute, MathUtils, AddEquation, Matrix4, UniformsUtils, UniformsLib, DynamicDrawUsage } from "three";
 import * as EasingFunctions from "@mozillareality/easing-functions";
 export function lerp(start, end, value) {
     return (end - start) * value + start;
@@ -71,7 +71,7 @@ const fragmentShader = `
 `;
 export class ParticleEmitter extends Mesh {
     constructor(texture) {
-        const planeGeometry = new PlaneBufferGeometry(1, 1, 1, 1);
+        const planeGeometry = new PlaneGeometry(1, 1, 1, 1);
         if (texture && !texture.flipY) {
             flipV(planeGeometry);
         }
@@ -126,7 +126,7 @@ export class ParticleEmitter extends Mesh {
     }
     updateParticles() {
         const texture = this.material.uniforms.map.value;
-        const planeGeometry = new PlaneBufferGeometry(1, 1, 1, 1);
+        const planeGeometry = new PlaneGeometry(1, 1, 1, 1);
         if (texture && !texture.flipY) {
             flipV(planeGeometry);
         }


### PR DESCRIPTION
Dear Mozilla,

in this PR I replace deprecated PlaneBufferGeometry with PlaneGeometry.

See also https://github.com/c-frame/aframe-gltf-model-plus/issues/5#issuecomment-2059817241 and following discussion.

All the best